### PR TITLE
tumor rebalance

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -59,8 +59,9 @@
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
 
 /datum/quirk/brainproblems/on_process()
-	if(!quirk_holder.isLivingSSD())
-		quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1)
+	if(quirk_holder.stat != DEAD)
+		if(!quirk_holder.isLivingSSD())
+			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1)
 
 /datum/quirk/deafness
 	name = "Deaf"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -59,7 +59,8 @@
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
 
 /datum/quirk/brainproblems/on_process()
-	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
+	if(!quirk_holder.isLivingSSD())
+		quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1)
 
 /datum/quirk/deafness
 	name = "Deaf"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tumors no longer deal damage while SSD & brain damage is halved

## Why It's Good For The Game

Dying while SSD kinda sucks

## Changelog

:cl:
balance: brain tumors no longer damage you while you are SSD and brain damage is halved
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
