### PR TITLE
Shetland Fixes

### DIFF
--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -377,6 +377,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer5,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "dl" = (
@@ -930,9 +933,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer5{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -944,6 +944,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -2145,6 +2151,9 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "sb" = (
@@ -2698,9 +2707,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "wW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-6"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -2709,6 +2715,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-6"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
@@ -3130,14 +3142,11 @@
 /obj/effect/turf_decal/number/zero{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5-9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5-10"
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9-10"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -4057,6 +4066,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "Jb" = (
@@ -5783,6 +5796,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes 2 flaws with the Shetland

1-
Power lines were crossed which was allowing SMES's to loop power around to themselves
2-
The aft hallway between the two engine areas was operating on free phantom power.... APC has since been installed to make the ghosts happy.

![image](https://github.com/user-attachments/assets/e2dc134b-c49d-4468-8519-e9b6d51349ce)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows less power calculation ticks
Allows the ship to use less power
Allows the hallway to run out of power.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Shetland Power Cables
fix: Shetland missing APC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
