### PR TITLE
V_Outpost turret corrections

### DIFF
--- a/modular_pentest/_maps/ruins_space/v_outpost.dmm
+++ b/modular_pentest/_maps/ruins_space/v_outpost.dmm
@@ -1156,7 +1156,7 @@
 	reqpower = 0
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/ruin/powered)
 "yQ" = (
 /turf/closed/indestructible/reinforced,
 /area/outpost/crew/dorm)
@@ -1300,7 +1300,7 @@
 	reqpower = 0
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/ruin/powered)
 "Bq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1756,7 +1756,7 @@
 	reqpower = 0
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/ruin/powered)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2171,7 +2171,7 @@
 	reqpower = 0
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/ruin/powered)
 "SR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Went about to correct an incorrect area such that the defense weapons can actually defend.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes stealing from Volkan a little harder. Volkan should really seek SYNAPSE.INC Protective services and apply a bike lock to their speeder so it cant be teleported away.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Fix: Makes the speeder harder to get by arming Volkan's Defenses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
