### PR TITLE
Renames Terragov's Gun Manufacturer

### DIFF
--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -56,7 +56,7 @@
 #define MANUFACTURER_SHARPLITE "the Sharplite Defense logo"
 #define MANUFACTURER_SHARPLITE_NEW "the Nanotrasen-Sharplite logo"
 #define MANUFACTURER_HUNTERSPRIDE "the Hunter's Pride Arms and Ammunition logo"
-#define MANUFACTURER_SOLARARMORIES "the Solarbundswaffenkammer emblem"
+#define MANUFACTURER_SOLARARMORIES "the Terragov Federal Armory emblem"
 #define MANUFACTURER_SCARBOROUGH "the Scarborough Arms logo"
 #define MANUFACTURER_EOEHOMA "the Eoehoma Firearms emblem"
 #define MANUFACTURER_NANOTRASEN_OLD "an outdated Nanotrasen logo"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes Solarbundswaffenkamer to the Terragov Federal Armory.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For the lore overhaul into something more fitting for TG Common Core, and also the old name's a bit uncomfortable...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
spellcheck: Terragov finally stopped sourcing their weapons from Switzerland, entire Solar System population rejoices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
