### PR TITLE
Disables V_Outpost

### DIFF
--- a/modular_pentest/_maps/ruins_space/_modular_space.dm
+++ b/modular_pentest/_maps/ruins_space/_modular_space.dm
@@ -11,12 +11,13 @@
 
 /// Maps that do not exist on shiptest code //
 
-/datum/map_template/ruin/pentest/space/v_outpost
-	cost = 200 //very rare spawn but possible.
-	id = "v_outpost"
-	suffix = "v_outpost.dmm"
-	name = "V's Outpost"
-	description = "A particular person's space outpost in the middle of nowhere. This place is used to build and prototype things."
+//V_Outpost disabled till rework.
+// /datum/map_template/ruin/pentest/space/v_outpost
+// 	cost = 200 //very rare spawn but possible.
+// 	id = "v_outpost"
+// 	suffix = "v_outpost.dmm"
+// 	name = "V's Outpost"
+// 	description = "A particular person's space outpost in the middle of nowhere. This place is used to build and prototype things."
 
 /datum/map_template/ruin/pentest/space/syndicircle
 	id = "provinggrounds"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I disabled my ruin as I intend to do a full rework and it is simply not difficult enough currently. 

## Why It's Good For The Game

The ruin was too easy and I cant be bothered to try continue to fix the turrets when I can just do the planned rework eventually. So, I decided to disable it for now.

