### PR TITLE
Adds/adjusts filling colors, reorganizes meat and snacks_pastry

### DIFF
--- a/code/modules/food_and_drinks/food/ration.dm
+++ b/code/modules/food_and_drinks/food/ration.dm
@@ -374,7 +374,7 @@
 /obj/item/reagent_containers/food/snacks/ration/side/white_sandwich_bread
 	name = "white sandwich bread"
 	desc = "Soft and fluffy white bread, perfect for making sandwiches or enjoying as a quick and simple snack."
-	filling_color = "#ffffff"
+	filling_color = "#F5ECE4"
 	tastes = list("bread" = 1)
 	foodtype = GRAIN
 
@@ -455,7 +455,7 @@
 /obj/item/reagent_containers/food/snacks/ration/side/white_bread_mini_loaf
 	name = "mini loaf of white bread"
 	desc = "A small loaf of soft and fluffy white bread, perfect for making sandwiches or enjoying as a simple snack."
-	filling_color = "#ffffff"
+	filling_color = "#F5ECE4"
 	tastes = list("bread" = 1)
 	foodtype = GRAIN
 
@@ -645,14 +645,14 @@
 /obj/item/reagent_containers/food/snacks/ration/snack/apple_slices
 	name = "apple slices"
 	desc = "Fresh and crisp apple slices, perfect for a refreshing and healthy snack option."
-	filling_color = "#ff3300"
+	filling_color = "#FFD6CC"
 	tastes = list("apple" = 1)
 	foodtype = FRUIT
 
 /obj/item/reagent_containers/food/snacks/ration/snack/candied_pineapple_chunks
 	name = "candied pineapple chunks"
 	desc = "Sweet and chewy candied pineapple chunks, offering a burst of tropical flavor in every bite."
-	filling_color = "#ff6600"
+	filling_color = "#FFCC00"
 	tastes = list("candied pineapple" = 1)
 	foodtype = SUGAR | FRUIT
 
@@ -680,14 +680,14 @@
 /obj/item/reagent_containers/food/snacks/ration/snack/patriotic_sugar_cookies
 	name = "patriotic sugar cookies"
 	desc = "Colorful sugar cookies with patriotic designs, providing a festive and sweet treat for special occasions."
-	filling_color = "#ffcc00"
+	filling_color = "#FFF0B3"
 	tastes = list("sugar cookies" = 1)
 	foodtype = SUGAR
 
 /obj/item/reagent_containers/food/snacks/ration/snack/oatmeal_cookie
 	name = "oatmeal cookie"
 	desc = "A delicious oatmeal cookie, offering a wholesome and satisfying treat for any time of day."
-	filling_color = "#663300"
+	filling_color = "#E8C676"
 	tastes = list("oatmeal cookie" = 1)
 	foodtype = SUGAR | GRAIN
 
@@ -701,14 +701,14 @@
 /obj/item/reagent_containers/food/snacks/ration/snack/dry_roasted_peanuts
 	name = "dry roasted peanuts"
 	desc = "Crunchy and flavorful dry roasted peanuts, a satisfying and protein-packed snack option."
-	filling_color = "#663300"
+	filling_color = "#B35900"
 	tastes = list("peanuts" = 1)
 	foodtype = FRUIT
 
 /obj/item/reagent_containers/food/snacks/ration/snack/jalapeno_cashews
 	name = "jalapeno cashews"
 	desc = "Savory cashews coated in a spicy jalapeno seasoning, creating a flavorful and satisfying snack option."
-	filling_color = "#663300"
+	filling_color = "#B35900"
 	tastes = list("jalapeno" = 1, "cashews" = 1)
 	foodtype = FRUIT
 
@@ -762,12 +762,12 @@
 
 /obj/item/reagent_containers/food/snacks/ration/condiment/peanut_butter
 	name = "peanut butter pack"
-	filling_color = "#664400"
+	filling_color = "#D18F4D"
 	list_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/consumable/peanut_butter = 5)
 
 /obj/item/reagent_containers/food/snacks/ration/condiment/chunky_peanut_butter
 	name = "chunky peanut butter pack"
-	filling_color = "#663300"
+	filling_color = "#D18F4D"
 	list_reagents = list(/datum/reagent/consumable/peanut_butter = 10)
 
 /obj/item/reagent_containers/food/snacks/ration/condiment/maple_syrup

--- a/code/modules/food_and_drinks/food/snacks/dough.dm
+++ b/code/modules/food_and_drinks/food/snacks/dough.dm
@@ -10,6 +10,7 @@
 	cooked_type = /obj/item/food/bread/plain
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6)
 	w_class = WEIGHT_CLASS_NORMAL
+	filling_color = "#EFD9C2"
 	tastes = list("dough" = 1)
 	foodtype = GRAIN
 
@@ -38,6 +39,7 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/pizzabread
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6)
 	w_class = WEIGHT_CLASS_NORMAL
+	filling_color = "#EFD9C2"
 	tastes = list("dough" = 1)
 	foodtype = GRAIN
 
@@ -49,6 +51,7 @@
 	custom_food_type = /obj/item/reagent_containers/food/snacks/customizable/pizza
 	list_reagents = list(/datum/reagent/consumable/nutriment = 7)
 	w_class = WEIGHT_CLASS_NORMAL
+	filling_color = "#CD853F"
 	tastes = list("bread" = 1)
 	foodtype = GRAIN
 
@@ -61,7 +64,7 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/bait/doughball
 	slices_num = 5
 	cooked_type = /obj/item/reagent_containers/food/snacks/bun
-	filling_color = "#CD853F"
+	filling_color = "#EFD9C2"
 	tastes = list("dough" = 1)
 	foodtype = GRAIN
 
@@ -85,6 +88,7 @@
 	cooked_type = /obj/item/food/cake/plain
 	list_reagents = list(/datum/reagent/consumable/nutriment = 9)
 	w_class = WEIGHT_CLASS_NORMAL
+	filling_color = "#EFD9C2"
 	tastes = list("batter" = 1)
 	foodtype = GRAIN | DAIRY
 
@@ -110,6 +114,7 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/pie/plain
 	list_reagents = list(/datum/reagent/consumable/nutriment = 9)
 	w_class = WEIGHT_CLASS_NORMAL
+	filling_color = "#EFD9C2"
 	tastes = list("dough" = 1)
 	foodtype = GRAIN | DAIRY
 
@@ -119,7 +124,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawpastrybase"
 	cooked_type = /obj/item/reagent_containers/food/snacks/pastrybase
-	filling_color = "#CD853F"
+	filling_color = "#EFD9C2"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
 	tastes = list("raw pastry" = 1)
 	foodtype = GRAIN | DAIRY

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -185,7 +185,6 @@
 	desc = "A slice from a huge tomato."
 	icon_state = "tomatomeat"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
-	filling_color = "#FF0000"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/killertomato
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/killertomato
 	tastes = list("tomato" = 1)
@@ -255,6 +254,35 @@
 	desc = "Much meatier than monkey meat."
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/cooking_oil = 5) //Plenty of fat!
 
+/obj/item/reagent_containers/food/snacks/meat/slab/chicken
+	name = "chicken meat"
+	icon_state = "birdmeat"
+	desc = "A slab of raw chicken. Remember to wash your hands!"
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/chicken
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/chicken
+	tastes = list("chicken" = 1)
+	filling_color = "#6B8E23"
+
+	/obj/item/reagent_containers/food/snacks/meat/slab/gondola
+	name = "gondola meat"
+	desc = "According to legends of old, consuming raw gondola flesh grants one inner peace."
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/tranquility = 5, /datum/reagent/consumable/cooking_oil = 3)
+	tastes = list("meat" = 4, "tranquility" = 1)
+	filling_color = "#9A6750"
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/gondola
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
+	foodtype = RAW | MEAT
+
+/obj/item/reagent_containers/food/snacks/meat/slab/penguin
+	name = "penguin meat"
+	icon_state = "birdmeat"
+	desc = "A slab of penguin meat."
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/cooking_oil = 3)
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/penguin
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/penguin
+	filling_color = "#B22222"
+	tastes = list("beef" = 1, "cod fish" = 1)
+
 /obj/item/reagent_containers/food/snacks/meat/rawbacon
 	name = "raw piece of bacon"
 	desc = "A raw piece of bacon."
@@ -276,26 +304,6 @@
 	tastes = list("bacon" = 1)
 	foodtype = MEAT | BREAKFAST
 
-/obj/item/reagent_containers/food/snacks/meat/slab/gondola
-	name = "gondola meat"
-	desc = "According to legends of old, consuming raw gondola flesh grants one inner peace."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/tranquility = 5, /datum/reagent/consumable/cooking_oil = 3)
-	tastes = list("meat" = 4, "tranquility" = 1)
-	filling_color = "#9A6750"
-	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/gondola
-	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
-	foodtype = RAW | MEAT
-
-/obj/item/reagent_containers/food/snacks/meat/slab/penguin
-	name = "penguin meat"
-	icon_state = "birdmeat"
-	desc = "A slab of penguin meat."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/cooking_oil = 3)
-	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/penguin
-	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/penguin
-	filling_color = "#B22222"
-	tastes = list("beef" = 1, "cod fish" = 1)
-
 /obj/item/reagent_containers/food/snacks/meat/rawcrab
 	name = "raw crab meat"
 	desc = "A pile of raw crab meat."
@@ -316,14 +324,6 @@
 	filling_color = "#DFB73A"
 	tastes = list("crab" = 1)
 	foodtype = MEAT
-
-/obj/item/reagent_containers/food/snacks/meat/slab/chicken
-	name = "chicken meat"
-	icon_state = "birdmeat"
-	desc = "A slab of raw chicken. Remember to wash your hands!"
-	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/chicken
-	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/chicken
-	tastes = list("chicken" = 1)
 
 ////////////////////////////////////// MEAT STEAKS ///////////////////////////////////////////////////////////
 
@@ -449,31 +449,37 @@
 	name = "raw bear cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/bear
 	tastes = list("meat" = 1, "salmon" = 1)
+	filling_color = "#FFB6C1"
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/xeno
 	name = "raw xeno cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/xeno
 	tastes = list("meat" = 1, "acid" = 1)
+	filling_color = "#32CD32"
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/spider
 	name = "raw spider cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/spider
 	tastes = list("cobwebs" = 1)
+	filling_color = "#7CFC00"
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
 	name = "raw gondola cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
 	tastes = list("meat" = 1, "tranquility" = 1)
+	filling_color = "#9A6750"
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/penguin
 	name = "raw penguin cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/penguin
 	tastes = list("beef" = 1, "cod fish" = 1)
+	filling_color = "#B22222"
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/chicken
 	name = "raw chicken cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/chicken
 	tastes = list("chicken" = 1)
+	filling_color = "#6B8E23"
 
 //Cooked cutlets
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -190,6 +190,7 @@
 	trash = /obj/item/trash/plate
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 4)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	filling_color = "D43131"
 	tastes = list("meat" = 1, "cabbage" = 1)
 	foodtype = MEAT | VEGETABLES
 
@@ -200,6 +201,7 @@
 	trash = /obj/item/trash/plate
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 6)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/ethanol/manly_dorf = 5)
+	filling_color = "#B22222"
 	tastes = list("meat" = 1, "salmon" = 1)
 	foodtype = MEAT | ALCOHOL
 
@@ -246,6 +248,7 @@
 	desc = "One hundred khinkalis? Do I look like a pig?"
 	icon_state = "khinkali"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/garlic = 1)
+	filling_color = "#F0F0F0"
 	cooked_type = /obj/item/reagent_containers/food/snacks/khinkali
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
 	foodtype = MEAT
@@ -359,7 +362,7 @@
 
 /obj/item/reagent_containers/food/snacks/nugget
 	name = "chicken nugget"
-	filling_color = "#B22222"
+	filling_color = "#E6B857"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	tastes = list("\"chicken\"" = 1)
@@ -390,6 +393,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/bbqsauce = 5)
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
+	filling_color = "#662008"
 	tastes = list("meat" = 3, "smokey sauce" = 1)
 	foodtype = MEAT
 
@@ -399,6 +403,7 @@
 	icon_state = "meatclown"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/banana = 2)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	filling_color = "#CD4122"
 	tastes = list("meat" = 5, "clowns" = 3, "sixteen teslas" = 1)
 	foodtype = MEAT
 
@@ -413,6 +418,7 @@
 	icon_state = "kebab"
 	w_class = WEIGHT_CLASS_NORMAL
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	filling_color = "#9C4814"
 	tastes = list("meat" = 3, "metal" = 1)
 	foodtype = MEAT
 

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -76,6 +76,7 @@
 	desc = "A slice from a huge mushroom."
 	icon_state = "hugemushroomslice"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
+	filling_color = "#876736"
 	tastes = list("mushroom" = 1)
 	foodtype = VEGETABLES
 
@@ -429,6 +430,7 @@
 	icon_state = "stuffed_legion"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 3, /datum/reagent/consumable/capsaicin = 1, /datum/reagent/medicine/tricordrazine = 5)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/capsaicin = 2, /datum/reagent/medicine/tricordrazine = 10)
+	filling_color = "#3B342B"
 	tastes = list("death" = 2, "rock" = 1, "meat" = 1, "hot peppers" = 1)
 	foodtype = MEAT
 
@@ -438,6 +440,7 @@
 	icon_state = "powercrepe"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 3, /datum/reagent/iron = 10)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/cherryjelly = 5)
+	filling_color = "#D1AE82"
 	force = 30
 	throwforce = 15
 	block_chance = 55
@@ -641,6 +644,7 @@
 	icon_state = "bran_requests"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/sodiumchloride = 5)
 	bonus_reagents = list(/datum/reagent/consumable/sodiumchloride = 10)
+	filling_color = "#D1AE82"
 	tastes = list("bran" = 4, "raisins" = 3, "salt" = 1)
 	foodtype = GRAIN | FRUIT | BREAKFAST
 

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -327,6 +327,33 @@
 	is_decorated = TRUE
 	filling_color = "#879630"
 
+	/obj/item/reagent_containers/food/snacks/donut/laugh
+	name = "sweet pea donut"
+	desc = "Goes great with a glass of Bastion Burbon!"
+	icon_state = "donut_laugh"
+	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
+	tastes = list("donut" = 3, "fizzy tutti frutti" = 1,)
+	is_decorated = TRUE
+	filling_color = "#803280"
+
+/obj/item/reagent_containers/food/snacks/donut/jelly/laugh
+	name = "sweet pea jelly donut"
+	desc = "Goes great with a glass of Bastion Burbon!"
+	icon_state = "jelly_laugh"
+	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
+	tastes = list("jelly" = 3, "donut" = 1, "fizzy tutti frutti" = 1)
+	is_decorated = TRUE
+	filling_color = "#803280"
+
+/obj/item/reagent_containers/food/snacks/donut/jelly/slimejelly/laugh
+	name = "sweet pea jelly donut"
+	desc = "Goes great with a glass of Bastion Burbon!"
+	icon_state = "jelly_laugh"
+	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
+	tastes = list("jelly" = 3, "donut" = 1, "fizzy tutti frutti" = 1)
+	is_decorated = TRUE
+	filling_color = "#803280"
+
 ////////////////////////////////////////////MUFFINS////////////////////////////////////////////
 
 /obj/item/reagent_containers/food/snacks/muffin
@@ -772,6 +799,18 @@
 	tastes = list("pastry" = 1, "sweetness" = 1)
 	foodtype = GRAIN | SUGAR
 
+/obj/item/reagent_containers/food/snacks/cannoli
+	name = "cannoli"
+	desc = "A sicilian treat that makes you into a wise guy."
+	icon_state = "cannoli"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 1)
+	filling_color = "#ffffff"
+	tastes = list("pastry" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
+
+// Pancakes //
+
 #define PANCAKE_MAX_STACK 10
 
 /obj/item/reagent_containers/food/snacks/pancakes
@@ -888,40 +927,3 @@
 	update_appearance()
 
 #undef PANCAKE_MAX_STACK
-
-/obj/item/reagent_containers/food/snacks/cannoli
-	name = "cannoli"
-	desc = "A sicilian treat that makes you into a wise guy."
-	icon_state = "cannoli"
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 1)
-	filling_color = "#ffffff"
-	tastes = list("pastry" = 1)
-	foodtype = GRAIN | DAIRY | SUGAR
-
-/obj/item/reagent_containers/food/snacks/donut/laugh
-	name = "sweet pea donut"
-	desc = "Goes great with a glass of Bastion Burbon!"
-	icon_state = "donut_laugh"
-	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
-	tastes = list("donut" = 3, "fizzy tutti frutti" = 1,)
-	is_decorated = TRUE
-	filling_color = "#803280"
-
-/obj/item/reagent_containers/food/snacks/donut/jelly/laugh
-	name = "sweet pea jelly donut"
-	desc = "Goes great with a glass of Bastion Burbon!"
-	icon_state = "jelly_laugh"
-	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
-	tastes = list("jelly" = 3, "donut" = 1, "fizzy tutti frutti" = 1)
-	is_decorated = TRUE
-	filling_color = "#803280"
-
-/obj/item/reagent_containers/food/snacks/donut/jelly/slimejelly/laugh
-	name = "sweet pea jelly donut"
-	desc = "Goes great with a glass of Bastion Burbon!"
-	icon_state = "jelly_laugh"
-	bonus_reagents = list(/datum/reagent/consumable/laughter = 3)
-	tastes = list("jelly" = 3, "donut" = 1, "fizzy tutti frutti" = 1)
-	is_decorated = TRUE
-	filling_color = "#803280"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As stated in the title, adds filling colors for a handful of foods and adjusts filling colors for raw spider and xeno cutlets to match their corresponding slabs. Some foods had filling colors that didn't make sense or match their sprite, so I adjusted those as well.

Also, reorganizes meat.dm and snacks_pastry.dm. Gotta keep all the donuts together.

## Why It's Good For The Game

Sandwiches are now slightly more predictable.

## Changelog

:cl:
add: Sets filling colors for a number of foods that didn't have one
fix: Adjusts filling colors for raw cutlets to match their corresponding slabs
spellcheck: Reorganized meat.dm and snacks_pastry.dm for clarity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
