### PR TITLE
Fixes Black Market Scamming you when you attempt to buy the Rusted Red Hardsuit

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/clothing.dm
@@ -260,7 +260,7 @@
 /datum/blackmarket_item/clothing/ramzi_suit
 	name = "Rusted Red Hardsuit"
 	desc = "A vintage ICW Era Gorlex Maruader hardsuit. The previous owner said we could have it when we pried it off their cold dead hands. Dry cleaning not included."
-	item = /obj/item/clothing/head/helmet/space/hardsuit/syndi/ramzi
+	item = /obj/item/clothing/suit/space/hardsuit/syndi/ramzi
 
 	price_min = 1500
 	price_max = 2500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One line fix to replace selling the helmet with the actual hardsuit

## Why It's Good For The Game

I got scammed by this personally so I actually PR'd a fix

## Changelog

:cl:
You will now receive the entire hardsuit when you buy the Rusted Red Hardsuit from the Black Market.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
