### PR TITLE
Corrects Blackmarket Stock Updating

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_item.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_item.dm
@@ -59,7 +59,7 @@
 /datum/blackmarket_item/proc/randomize_stock()
 	stock = rand(stock_min, stock_max)
 
-/datum/blackmarket_item/proc/cycle(price = TRUE, availibility = TRUE, stock = TRUE, force_appear = FALSE)
+/datum/blackmarket_item/proc/cycle(price = TRUE, availibility = TRUE, stock = TRUE, force_appear = FALSE) //PENTEST CHANGE - STOCK = TRUE
 	if(price)
 		randomize_price()
 	if(stock)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Was brought to my attention that Shiptest set the stock variable to FALSE when it came to the hourly restocking.

This meant that the number of items never actually reset when it was restock time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Things will actually restock when they should. Meaning more people can get things from the blackmarket.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Blackmarket Brokers have fixed their Supply Chain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
