### PR TITLE
[In Progress] SolGov to DREAM conversion

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -64,7 +64,7 @@
 		list(fax_name = "Nanotrasen Central Command", fax_id = "nanotrasen", color = "green", emag_needed = FALSE),
 		list(fax_name = "Outpost Authority", fax_id = "outpost", color = "orange", emag_needed = FALSE),
 		list(fax_name = "IRMG Mothership", fax_id = "inteq", color = "yellow", emag_needed = FALSE),
-		list(fax_name = "Terran Frontier Affairs", fax_id = "solgov", color = "teal", emag_needed = FALSE),
+		list(fax_name = "DREAM Frontier Affairs", fax_id = "solgov", color = "teal", emag_needed = FALSE),
 		list(fax_name = "Roumain Council of Huntsmen", fax_id = "roumain", color = "brown", emag_needed = FALSE),
 		list(fax_name = "Confederated League Leadership", fax_id = "minutemen", color = "blue", emag_needed = FALSE),
 		list(fax_name = "PGF Military High Command", fax_id = "gezena", color = "olive", emag_needed = FALSE),

--- a/modular_pentest/modules/faction_dream/code/modules/antagonists/ert/dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/antagonists/ert/dream.dm
@@ -2,16 +2,16 @@
 // ** Dream **
 // ********************************************************************
 /datum/antagonist/ert/solgov
-	name = "Dreamer Emergency Response Personnel"
+	name = "DREAM Emergency Response Personnel"
 	outfit = /datum/outfit/job/solgov/ert
 	random_names = FALSE
-	role = "Dreamer ERT"
+	role = "DREAM ERT"
 
 /datum/antagonist/ert/solgov/inspector
-	name = "Dreamer Inspector"
+	name = "DREAM Inspector"
 	outfit = /datum/outfit/job/solgov/ert/inspector
-	role = "Dreamer Inspector"
+	role = "DREAM Inspector"
 
 /datum/antagonist/ert/solgov/inspector/greet()
-	to_chat(owner, "<B><font size=3 color=red>You are a Inspector for Dream.</font></B>")
+	to_chat(owner, "<B><font size=3 color=red>You are a Inspector for DREAM.</font></B>")
 	to_chat(owner, "The Department of Administrative Affairs is sending you to [station_name()] with the task: [ert_team.mission.explanation_text]")

--- a/modular_pentest/modules/faction_dream/code/modules/areas/ship_areas.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/areas/ship_areas.dm
@@ -1,0 +1,6 @@
+// Solgov to DREAM conversion
+
+/area/ship/crew/solgov
+	name = "DREAM Consulate"
+	icon_state = "solgov"
+	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
@@ -118,6 +118,9 @@
 /obj/item/clothing/head/hooded/winterhood/solgov
 	icon_state = "hood_solgov"
 
+/obj/item/clothing/suit/space/hardsuit/solgov/suns
+	desc = "A well decorated spaceworthy suit." // removed reference to SolGov in the description
+
 // Headgear
 
 /obj/item/clothing/head/solgov

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
@@ -183,7 +183,7 @@
 	name = "DREAM captain's cloak"
 	desc = "Worn by DREAM captains. It smells faintly of patchouli."
 
-// Accesories
+// Accessories
 
 /obj/item/clothing/accessory/waistcoat/solgov
 	name = "DREAM waistcoat"

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
@@ -1,120 +1,119 @@
 // Uniforms
 
 /obj/item/clothing/under/solgov
-	name = "\improper SolGov tunic"
-	desc = "Standard combat tunic used by Sonnensoldners."
+	name = "\improper DREAM tunic"
+	desc = "Standard combat tunic used by Dreamers."
 
 /obj/item/clothing/under/solgov/terragov
-	name = "\improper TerraGov tunic"
-	desc = "Specialized combat tunic utilized by Sonnensoldners serving the Terran Regency."
+	name = "\improper DREAM tunic"
+	desc = "Specialized combat tunic utilized by Dreamers."
 
 /obj/item/clothing/under/solgov/dress
-	name = "\improper SolGov dress"
-	desc = "A formal SolGov white dress, used by civilians and officials alike."
+	name = "\improper DREAM dress"
+	desc = "A formal DREAM white dress used by civilians and officials alike."
 
 /obj/item/clothing/under/solgov/formal
-	name = "\improper SolGov formal suit"
-	desc = "A formal SolGov uniform, commonly used by representatives and officials."
+	name = "\improper DREAM formal suit"
+	desc = "A formal DREAM uniform commonly used by representatives and officials."
 
 /obj/item/clothing/under/solgov/formal/skirt
-	name = "\improper SolGov formal suitskirt"
-	desc = "A formal SolGov uniform, commonly used by representatives and officials."
+	name = "\improper DREAM formal suitskirt"
+	desc = "A formal DREAM uniform commonly used by representatives and officials."
 
 /obj/item/clothing/under/solgov/formal/terragov
-	name = "\improper TerraGov formal uniform"
-	desc = "A formal SolGov uniform, for special occasions. This one is colored in original TerraGov green."
-
+	name = "\improper DREAM formal uniform"
+	desc = "A formal DREAM uniform for special occasions."
 
 /obj/item/clothing/under/solgov/formal/captain
-	name = "\improper SolGov captain uniform"
-	desc = "A formal SolGov uniform, utilized by captains of SolGov vessels."
+	name = "\improper DREAM captain uniform"
+	desc = "A formal DREAM uniform, utilized by captains of DREAM vessels."
 
 /obj/item/clothing/under/plasmaman/solgov
-	name = "\improper SolGov envirosuit"
-	desc = "The pride of Solarian plasmamen everywhere- though this tends to be a somewhat exclusive club, due to Sol's aggressive workplace safety regulations."
+	name = "\improper DREAM envirosuit"
+	desc = "The pride of plasmamen everywhere."
 
 /obj/item/clothing/head/helmet/space/plasmaman/solgov
-	name = "\improper SolGov envirosuit helmet"
+	name = "\improper DREAM envirosuit helmet"
 	desc = "A generic white envirohelmet with a secondary blue."
 
 // Oversuits
 
 /obj/item/clothing/suit/armor/vest/solgov
-	name = "\improper Sonnensoldner gambison"
-	desc = "A standard armor vest fielded for SolGov's Sonnensoldners."
+	name = "\improper Dreamer gambison"
+	desc = "A standard armor vest fielded for Dreamers."
 
 /obj/item/clothing/suit/armor/vest/solgov/overseer
-	name = "\improper SolGov Overseer robe"
-	desc = "An elaborately designed robe utilized by SolGov overseers."
+	name = "\improper DREAM Overseer robe"
+	desc = "An elaborately designed robe utilized by DREAM overseers."
 
 /obj/item/clothing/suit/armor/vest/solgov/captain
-	name = "\improper SolGov Captain coat"
-	desc = "An armored coat typically used by SolGov captains."
+	name = "\improper DREAM Captain coat"
+	desc = "An armored coat typically used by DREAM captains."
 
 /obj/item/clothing/suit/armor/vest/solgov/Initialize()
 	. = ..()
 	allowed |= list(/obj/item/gun/ballistic/automatic/assault/swiss_cheese, /obj/item/tank)
 
 /obj/item/clothing/head/helmet/space/solgov
-	name = "\improper SolGov Vacuum Helmet"
+	name = "\improper DREAM Vacuum Helmet"
 	desc = "This space-proof helmet is meant to be worn with a matching T-MA suit."
 
 /obj/item/clothing/suit/space/solgov
-	name = "\improper SolGov Vacuum Suit"
-	desc = "Originally designed by independent contractors on Luna for the purposes of survival in hazardous environments, the lightweight Tortoise Microlite Armored Suit now sees widespread use by SolGov's exploration teams."
+	name = "\improper DREAM Vacuum Suit"
+	desc = "Originally designed by independent contractors on Luna for the purposes of survival in hazardous environments, the lightweight Tortoise Microlite Armored Suit now sees widespread use by DREAM's exploration teams."
 
 /obj/item/clothing/head/helmet/space/hardsuit/solgov
-	name = "\improper SolGov hardsuit helmet"
-	desc = "An armored spaceproof helmet, its visor is reminiscent of knights of yore."
+	name = "\improper DREAM hardsuit helmet"
+	desc = "An armored spaceproof helmet. Its visor is reminiscent of knights of yore."
 
 /obj/item/clothing/suit/space/hardsuit/solgov
 
-	name = "\improper SolGov hardsuit"
+	name = "\improper DREAM hardsuit"
 	desc = "An armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile."
 
 /obj/item/clothing/suit/hazardvest/solgov
-	name = "SolGov hazard vest"
-	desc = "A high-visibility vest used in work zones by solarian engineers."
+	name = "DREAM hazard vest"
+	desc = "A high-visibility vest used in work zones by Dreamer engineers."
 
 /obj/item/clothing/suit/solgov
-	name = "SolGov robe"
-	desc = "A set of plain SolGov robes, commonly used by civilians."
+	name = "DREAM robe"
+	desc = "A set of plain DREAM robes commonly used by civilians."
 
 /obj/item/clothing/suit/solgov/dress
-	name = "SolGov dress"
-	desc = "A plain SolGov dress, commonly used by civilians."
+	name = "DREAM dress"
+	desc = "A plain DREAM dress commonly used by civilians."
 
 /obj/item/clothing/suit/solgov/suit
-	name = "SolGov suit"
-	desc = "A formal SolGov suit, commonly used by civilians."
+	name = "DREAM suit"
+	desc = "A formal DREAM suit commonly used by civilians."
 
 /obj/item/clothing/suit/solgov/bureaucrat
-	name = "SolGov bureaucrat robe"
-	desc = "A set of unique SolGov robes, utilized by Solarian Bureaucrats."
+	name = "DREAM bureaucrat robe"
+	desc = "A set of unique DREAM robes utilized by bureaucrats."
 
 /obj/item/clothing/suit/solgov/overcoat
-	name = "SolGov overcoat"
-	desc = "A traditional solarian overcoat, used by cilivians and ship crews alike."
+	name = "DREAM overcoat"
+	desc = "A traditional overcoat used by civilians and crews alike."
 
 /obj/item/clothing/suit/solgov/jacket
-	name = "SolGov jacket"
-	desc = "A plain SolGov jacket, commonly used by civilians."
+	name = "DREAM jacket"
+	desc = "A plain DREAM jacket commonly used by civilians."
 
 /obj/item/clothing/suit/toggle/solgov
-	name = "\improper SolGov coat"
-	desc = "An armored coat worn for special occasions. This one is dyed in SolGov blue."
+	name = "\improper DREAM coat"
+	desc = "An armored coat worn for special occasions."
 
 /obj/item/clothing/suit/toggle/solgov/terragov
-	name = "\improper Terragov coat"
-	desc = "An armored coat worn for special occasions. This one is still dyed in original TerraGov green."
+	name = "\improper DREAM coat"
+	desc = "An armored coat worn for special occasions."
 
 /obj/item/clothing/suit/armor/solgov_trenchcoat
-	name = "\improper SolGov trenchcoat"
-	desc = "A SolGov official's trenchcoat. Has a lot of pockets."
+	name = "\improper DREAM trenchcoat"
+	desc = "A DREAM official's trenchcoat. Has a lot of pockets."
 
 /obj/item/clothing/suit/hooded/wintercoat/solgov
-	name = "solgov winter coat"
-	desc = "An environment-resistant wintercoat in the colors of the Solarian Confederation."
+	name = "DREAM winter coat"
+	desc = "An environment-resistant wintercoat."
 
 /obj/item/clothing/head/hooded/winterhood/solgov
 	icon_state = "hood_solgov"
@@ -124,70 +123,70 @@
 // Headgear
 
 /obj/item/clothing/head/solgov
-	name = "\improper SolGov officer's cap"
-	desc = "A blue cap worn by high-ranking officers of SolGov."
+	name = "\improper DREAM officer's cap"
+	desc = "A blue cap worn by high-ranking officers of DREAM."
 
 /obj/item/clothing/head/solgov/terragov
-	name = "\improper TerraGov officer's cap"
-	desc = "A cap worn by high-ranking officers of SolGov. This one is still in original TerraGov green."
+	name = "\improper DREAM officer's cap"
+	desc = "A cap worn by high-ranking officers of DREAM."
 
 /obj/item/clothing/head/solgov/sonnensoldner
-	name = "\improper Sonnensoldner Hat"
-	desc = "A standard-issue SolGov hat adorned with a feather, commonly used by Sonnensoldners."
+	name = "\improper Dreamer Hat"
+	desc = "A standard-issue hat adorned with a feather. Commonly used by Dreamers."
 
 /obj/item/clothing/head/solgov/captain
-	name = "\improper SolGov bicorne hat"
-	desc = "A unique bicorne hat given to Solarian Captains on expeditionary missions."
+	name = "\improper DREAM bicorne hat"
+	desc = "A unique bicorne hat given to DREAM Captains on expeditionary missions."
 
 /obj/item/clothing/head/beret/solgov
-	name = "\improper SolGov beret"
-	desc = "A beret with SolGov's emblem emblazoned on it. Colored in SolGov blue."
+	name = "\improper DREAM beret"
+	desc = "A beret with DREAM's emblem emblazoned on it."
 
 /obj/item/clothing/head/beret/solgov/plain
-	name = "\improper SolGov beret"
+	name = "\improper DREAM beret"
 	desc = "A plain blue beret. It looks like it's missing something."
 
 /obj/item/clothing/head/beret/solgov/terragov
-	name = "\improper TerraGov beret"
-	desc = "A beret with SolGov's emblem emblazoned on it. It's still colored in original TerraGov green."
+	name = "\improper DREAM beret"
+	desc = "A beret with DREAM's emblem emblazoned on it."
 
 /obj/item/clothing/head/beret/solgov/terragov/plain
-	name = "\improper TerraGov beret"
-	desc = "A plain beret colored in original TerraGov green. It looks like it's missing something."
+	name = "\improper DREAM beret"
+	desc = "A plain beret colored in original DREAM green. It looks like it's missing something."
 
 /obj/item/clothing/head/fedora/solgov
-	name = "solarian hat"
-	desc = "A slick blue hat used by both solarian civilians and physicists."
+	name = "Dreamer hat"
+	desc = "A slick blue hat used by physicists."
 
 /obj/item/clothing/head/flatcap/solgov
-	name = "solarian flat cap"
-	desc = "A working solarian's hat, commonly used by Logistics Deck Officers."
+	name = "Dreamer flat cap"
+	desc = "A working Dreamer's hat, commonly used by Logistics Deck Officers."
 
 /obj/item/clothing/head/hardhat/solgov
 
 /obj/item/clothing/head/solgov_surgery
-	name = "SolGov surgery cap"
-	desc = "It's a surgery cap utilized by solarian doctors."
+	name = "DREAM surgery cap"
+	desc = "It's a surgery cap utilized by Dreamer doctors."
 
 // Neckwear
 
 /obj/item/clothing/neck/stripedsolgovscarf
-	name = "striped solgov scarf"
+	name = "striped DREAM scarf"
 
 /obj/item/clothing/neck/cloak/overseer
-	name = "SolGov overseer's cloak"
-	desc = "Worn by the Overseer. It smells faintly of bureaucracy."
+	name = "DREAM overseer's cloak"
+	desc = "Worn by the Overseer. It smells faintly of patchouli."
 
 /obj/item/clothing/neck/cloak/solgov
-	name = "SolGov weibel"
-	desc = "Worn by SolGov officials. It smells faintly of bureaucracy."
+	name = "DREAM weibel"
+	desc = "Worn by DREAM officials. It smells faintly of patchouli."
 
 /obj/item/clothing/neck/cloak/solgovcap
-	name = "SolGov captain's cloak"
-	desc = "Worn by SolGov captains. It smells faintly of bureaucracy."
+	name = "DREAM captain's cloak"
+	desc = "Worn by DREAM captains. It smells faintly of patchouli."
 
 // Accesories
 
 /obj/item/clothing/accessory/waistcoat/solgov
-	name = "solgov waistcoat"
-	desc = "A standard issue waistcoat in solgov colors."
+	name = "DREAM waistcoat"
+	desc = "A standard issue waistcoat in DREAM colors."

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/factions/_solgov_to_dream.dm
@@ -2,53 +2,53 @@
 
 /obj/item/clothing/under/solgov
 	name = "\improper DREAM tunic"
-	desc = "Standard combat tunic used by Dreamers."
+	desc = "Standard tunic commonly worn by Dreamers."
 
 /obj/item/clothing/under/solgov/terragov
 	name = "\improper DREAM tunic"
-	desc = "Specialized combat tunic utilized by Dreamers."
+	desc = "Special tunic commonly worn by Dreamers."
 
 /obj/item/clothing/under/solgov/dress
 	name = "\improper DREAM dress"
-	desc = "A formal DREAM white dress used by civilians and officials alike."
+	desc = "A formal white dress commonly worn by Dreamers."
 
 /obj/item/clothing/under/solgov/formal
 	name = "\improper DREAM formal suit"
-	desc = "A formal DREAM uniform commonly used by representatives and officials."
+	desc = "A formal suit commonly worn by DREAM officials. Paired with pants."
 
 /obj/item/clothing/under/solgov/formal/skirt
 	name = "\improper DREAM formal suitskirt"
-	desc = "A formal DREAM uniform commonly used by representatives and officials."
+	desc = "A formal suit commonly worn by DREAM officials. Paired with a skirt."
 
 /obj/item/clothing/under/solgov/formal/terragov
 	name = "\improper DREAM formal uniform"
-	desc = "A formal DREAM uniform for special occasions."
+	desc = "A formal uniform for special occasions."
 
 /obj/item/clothing/under/solgov/formal/captain
 	name = "\improper DREAM captain uniform"
-	desc = "A formal DREAM uniform, utilized by captains of DREAM vessels."
+	desc = "A formal uniform worn by captains of DREAM vessels."
 
 /obj/item/clothing/under/plasmaman/solgov
 	name = "\improper DREAM envirosuit"
-	desc = "The pride of plasmamen everywhere."
+	desc = "A sleek envirosuit with the DREAM insignia on it."
 
 /obj/item/clothing/head/helmet/space/plasmaman/solgov
 	name = "\improper DREAM envirosuit helmet"
-	desc = "A generic white envirohelmet with a secondary blue."
+	desc = "A sleek envirohelmet with the DREAM insignia on it."
 
 // Oversuits
 
 /obj/item/clothing/suit/armor/vest/solgov
-	name = "\improper Dreamer gambison"
-	desc = "A standard armor vest fielded for Dreamers."
+	name = "\improper DREAM anjia" // yay get some of that Chinese flavor
+	desc = "A flexible plated vest for Dreamers."
 
 /obj/item/clothing/suit/armor/vest/solgov/overseer
-	name = "\improper DREAM Overseer robe"
-	desc = "An elaborately designed robe utilized by DREAM overseers."
+	name = "\improper DREAM robe"
+	desc = "A robe worn by Dreamers."
 
 /obj/item/clothing/suit/armor/vest/solgov/captain
 	name = "\improper DREAM Captain coat"
-	desc = "An armored coat typically used by DREAM captains."
+	desc = "An armored coat worn by DREAM captains."
 
 /obj/item/clothing/suit/armor/vest/solgov/Initialize()
 	. = ..()
@@ -56,7 +56,7 @@
 
 /obj/item/clothing/head/helmet/space/solgov
 	name = "\improper DREAM Vacuum Helmet"
-	desc = "This space-proof helmet is meant to be worn with a matching T-MA suit."
+	desc = "This space-proof helmet with the DREAM insignia on it."
 
 /obj/item/clothing/suit/space/solgov
 	name = "\improper DREAM Vacuum Suit"
@@ -64,48 +64,48 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/solgov
 	name = "\improper DREAM hardsuit helmet"
-	desc = "An armored spaceproof helmet. Its visor is reminiscent of knights of yore."
+	desc = "An armored spaceproof helmet with the DREAM insignia."
 
 /obj/item/clothing/suit/space/hardsuit/solgov
 
 	name = "\improper DREAM hardsuit"
-	desc = "An armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile."
+	desc = "An armored spaceproof suit with the DREAM insignia. A powered exoskeleton keeps the suit light and mobile."
 
 /obj/item/clothing/suit/hazardvest/solgov
 	name = "DREAM hazard vest"
-	desc = "A high-visibility vest used in work zones by Dreamer engineers."
+	desc = "A high-visibility vest used in work zones by DREAM engineers."
 
 /obj/item/clothing/suit/solgov
 	name = "DREAM robe"
-	desc = "A set of plain DREAM robes commonly used by civilians."
+	desc = "A set of plain robes commonly worn by Dreamers."
 
 /obj/item/clothing/suit/solgov/dress
 	name = "DREAM dress"
-	desc = "A plain DREAM dress commonly used by civilians."
+	desc = "A plain dress commonly worn by Dreamers."
 
 /obj/item/clothing/suit/solgov/suit
 	name = "DREAM suit"
-	desc = "A formal DREAM suit commonly used by civilians."
+	desc = "A formal suit commonly worn by Dreamers."
 
 /obj/item/clothing/suit/solgov/bureaucrat
-	name = "DREAM bureaucrat robe"
-	desc = "A set of unique DREAM robes utilized by bureaucrats."
+	name = "DREAM recruiter robe" // NOTE THIS IS NO LONGER A BUREAUCRAT, BUT A RECRUITER
+	desc = "A set of robes designed to be worn by DREAM recruiters."
 
 /obj/item/clothing/suit/solgov/overcoat
 	name = "DREAM overcoat"
-	desc = "A traditional overcoat used by civilians and crews alike."
+	desc = "A traditional overcoat commonly worn by Dreamers."
 
 /obj/item/clothing/suit/solgov/jacket
 	name = "DREAM jacket"
-	desc = "A plain DREAM jacket commonly used by civilians."
+	desc = "A plain jacket commonly worn by Dreamers."
 
 /obj/item/clothing/suit/toggle/solgov
 	name = "\improper DREAM coat"
-	desc = "An armored coat worn for special occasions."
+	desc = "An armored coat for special occasions."
 
 /obj/item/clothing/suit/toggle/solgov/terragov
 	name = "\improper DREAM coat"
-	desc = "An armored coat worn for special occasions."
+	desc = "An armored coat for special occasions."
 
 /obj/item/clothing/suit/armor/solgov_trenchcoat
 	name = "\improper DREAM trenchcoat"
@@ -118,13 +118,11 @@
 /obj/item/clothing/head/hooded/winterhood/solgov
 	icon_state = "hood_solgov"
 
-
-
 // Headgear
 
 /obj/item/clothing/head/solgov
 	name = "\improper DREAM officer's cap"
-	desc = "A blue cap worn by high-ranking officers of DREAM."
+	desc = "A cap worn by high-ranking officers of DREAM."
 
 /obj/item/clothing/head/solgov/terragov
 	name = "\improper DREAM officer's cap"
@@ -132,11 +130,11 @@
 
 /obj/item/clothing/head/solgov/sonnensoldner
 	name = "\improper Dreamer Hat"
-	desc = "A standard-issue hat adorned with a feather. Commonly used by Dreamers."
+	desc = "A hat commonly worn by Dreamers."
 
 /obj/item/clothing/head/solgov/captain
 	name = "\improper DREAM bicorne hat"
-	desc = "A unique bicorne hat given to DREAM Captains on expeditionary missions."
+	desc = "A DREAM Captain's hat. It smells like patchouli."
 
 /obj/item/clothing/head/beret/solgov
 	name = "\improper DREAM beret"
@@ -144,7 +142,7 @@
 
 /obj/item/clothing/head/beret/solgov/plain
 	name = "\improper DREAM beret"
-	desc = "A plain blue beret. It looks like it's missing something."
+	desc = "A plain beret. It looks like it's missing something."
 
 /obj/item/clothing/head/beret/solgov/terragov
 	name = "\improper DREAM beret"
@@ -152,33 +150,33 @@
 
 /obj/item/clothing/head/beret/solgov/terragov/plain
 	name = "\improper DREAM beret"
-	desc = "A plain beret colored in original DREAM green. It looks like it's missing something."
+	desc = "A plain beret. It looks like it's missing something."
 
 /obj/item/clothing/head/fedora/solgov
-	name = "Dreamer hat"
-	desc = "A slick blue hat used by physicists."
+	name = "DREAM fedora"
+	desc = "A fedora with the DREAM insignia on it. Why would anyone wear this?"
 
 /obj/item/clothing/head/flatcap/solgov
 	name = "Dreamer flat cap"
-	desc = "A working Dreamer's hat, commonly used by Logistics Deck Officers."
+	desc = "A working Dreamer's hat."
 
 /obj/item/clothing/head/hardhat/solgov
 
 /obj/item/clothing/head/solgov_surgery
 	name = "DREAM surgery cap"
-	desc = "It's a surgery cap utilized by Dreamer doctors."
+	desc = "It's a surgery cap utilized by DREAM physicians."
 
 // Neckwear
 
 /obj/item/clothing/neck/stripedsolgovscarf
-	name = "striped DREAM scarf"
+	name = "striped Dreamer scarf"
 
 /obj/item/clothing/neck/cloak/overseer
-	name = "DREAM overseer's cloak"
-	desc = "Worn by the Overseer. It smells faintly of patchouli."
+	name = "DREAM cloak"
+	desc = "A cloak for Dreamers. It smells faintly of patchouli."
 
 /obj/item/clothing/neck/cloak/solgov
-	name = "DREAM weibel"
+	name = "DREAM cloak"
 	desc = "Worn by DREAM officials. It smells faintly of patchouli."
 
 /obj/item/clothing/neck/cloak/solgovcap

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/misc_clothing.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/misc_clothing.dm
@@ -1,0 +1,8 @@
+// More DREAM conversion - Misc Clothing Overrides //
+
+/datum/blackmarket_item/clothing/terragov
+	desc = "These were supposed to be shipped to a museum celebrating Terran history. Honestly, we're doing them a favour. Clothes are meant to be worn rather than kept in some dusty box."
+
+/obj/item/clothing/under/dress/sailor
+	desc = "A traditional Lunar dress popularized by DREAM sailors. Despite its roots as a formal uniform, it is now often worn by civilians outside of its naval context. The crisp cloth evokes feelings of order and discipline."
+

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/ert/dream_ert.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/ert/dream_ert.dm
@@ -1,5 +1,5 @@
 /datum/outfit/job/solgov/ert
-	name = "ERT - Dreamer Shock Trooper"
+	name = "ERT - DREAM Shock Trooper"
 	id_assignment = "Shock Trooper"
 	jobtype = /datum/job/officer
 	job_icon = "sonnensoldner"
@@ -18,9 +18,8 @@
 	box = /obj/item/storage/box/survival
 	l_hand = /obj/item/melee/duelenergy/halberd
 
-
 /datum/outfit/job/solgov/ert/inspector
-	name = "ERT - Dreamer Inspector"
+	name = "ERT - DREAM Inspector"
 	id_assignment = "Inspector"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "solgovrepresentative"

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/factions/dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/factions/dream.dm
@@ -66,7 +66,7 @@
 	name = "DREAM - Peace Officer"
 	id_assignment = "Peace Officer"
 	jobtype = /datum/job/officer
-	job_icon = "Sonnensöldner"
+	job_icon = "Sonnensöldner" // change all the job icons
 
 	id = /obj/item/card/id/solgov
 	uniform = /obj/item/clothing/under/solgov

--- a/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/factions/dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/clothing/outfits/factions/dream.dm
@@ -11,8 +11,8 @@
 	H.grant_language(/datum/language/solarian_international)
 
 /datum/outfit/job/solgov/assistant
-	name = "Dreamer - Scribe"
-	id_assignment = "Scribe"
+	name = "DREAM - Secretary"
+	id_assignment = "Secretary"
 	jobtype = /datum/job/assistant
 	job_icon = "scribe"
 
@@ -22,8 +22,8 @@
 	suit = /obj/item/clothing/suit/solgov
 
 /datum/outfit/job/solgov/bureaucrat
-	name = "Dreamer - Bureaucrat"
-	id_assignment = "Bureaucrat"
+	name = "DREAM - Recruiter"
+	id_assignment = "Recruiter"
 	jobtype = /datum/job/curator
 	job_icon = "curator"
 
@@ -40,7 +40,7 @@
 	)
 
 /datum/outfit/job/solgov/captain
-	name = "Dreamer - Captain"
+	name = "DREAM - Captain"
 	jobtype = /datum/job/captain
 	job_icon = "solgovrepresentative" // idk
 
@@ -63,8 +63,8 @@
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/captain)
 
 /datum/outfit/job/solgov/sonnensoldner
-	name = "Dreamer - Shock Trooper"
-	id_assignment = "Shock Trooper"
+	name = "DREAM - Peace Officer"
+	id_assignment = "Peace Officer"
 	jobtype = /datum/job/officer
 	job_icon = "Sonnensöldner"
 
@@ -82,7 +82,7 @@
 	backpack_contents = list(/obj/item/crowbar/power)
 
 /datum/outfit/job/solgov/representative
-	name = "Dreamer - Representative"
+	name = "DREAM - Communications Specialist"
 	jobtype = /datum/job/solgov
 	job_icon = "solgovrepresentative"
 
@@ -106,7 +106,7 @@
 	)
 
 /datum/outfit/job/solgov/overseer
-	name = "Dreamer - Overseer"
+	name = "DREAM - Outreach Director"
 	id_assignment = "Overseer"
 	jobtype = /datum/job/head_of_personnel
 	job_icon = "headofpersonnel"
@@ -125,7 +125,7 @@
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/officer)
 
 /datum/outfit/job/solgov/doctor
-	name = "Dreamer - Medical Doctor"
+	name = "DREAM - Field Physician"
 	jobtype = /datum/job/doctor
 	job_icon = "medicaldoctor"
 
@@ -144,7 +144,7 @@
 	box = /obj/item/storage/box/survival/medical
 
 /datum/outfit/job/solgov/miner
-	name = "Dreamer - Field Engineer"
+	name = "DREAM - Field Engineer"
 	id_assignment = "Field Engineer"
 	jobtype = /datum/job/mining
 	job_icon = "shaftminer"
@@ -169,7 +169,7 @@
 	box = /obj/item/storage/box/survival/mining
 
 /datum/outfit/job/solgov/psychologist
-	name = "Dreamer - Psychologist"
+	name = "DREAM - Social Worker"
 	jobtype = /datum/job/psychologist
 	job_icon = "psychologist"
 
@@ -186,10 +186,10 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 
 /datum/outfit/job/solgov/patient
-	name = "Dreamer - Attentive Care Patient"
-	id_assignment = "Attentive Care Patient"
+	name = "DREAM - Refugee"
+	id_assignment = "Refugee"
 	jobtype = /datum/job/prisoner
-	job_icon = "assistant" // todo: bug rye for patient icon // rye. rye. give me 50 gazillion billion dollars paypal
+	job_icon = "assistant"
 
 	id = /obj/item/card/id/patient
 	uniform = /obj/item/clothing/under/rank/medical/gown
@@ -197,8 +197,8 @@
 	shoes = /obj/item/clothing/shoes/sandal/slippers
 
 /datum/outfit/job/solgov/engineer
-	name = "Dreamer - Ship Engineer"
-	id_assignment = "Ship Engineer"
+	name = "DREAM - Ship Mechanic"
+	id_assignment = "Ship Mechanic"
 	jobtype = /datum/job/engineer
 	job_icon = "stationengineer"
 
@@ -220,8 +220,8 @@
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
 
 /datum/outfit/job/solgov/quartermaster
-	name = "Dreamer - Logistics Deck Officer"
-	id_assignment = "Logistics Deck Officer"
+	name = "DREAM - Procurement Officer"
+	id_assignment = "Procurement Officer"
 	jobtype = /datum/job/qm
 	job_icon = "quartermaster"
 

--- a/modular_pentest/modules/faction_dream/code/modules/datums/ert/ert_dream.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/datums/ert/ert_dream.dm
@@ -3,16 +3,16 @@
 	opendoors = FALSE
 	leader_role = /datum/antagonist/ert/solgov
 	roles = list(/datum/antagonist/ert/solgov)
-	mission = "Intervene in Terran interests."
-	rename_team = "Dream Shock Trooper Team"
-	polldesc = "a Dreamer mercenary team"
+	mission = "Advance DREAM's interests." // change this later
+	rename_team = "DREAM Peace Trooper Team"  // idk????
+	polldesc = "a DREAM mercenary team"
 
 /datum/ert/solgov/inspector
 	teamsize = 1
 	leader_role = /datum/antagonist/ert/solgov/inspector
 	roles = list(/datum/antagonist/ert/solgov/inspector)
-	rename_team = "Dreamer Inspector"
-	polldesc = "a dream inspector"
+	rename_team = "DREAM Inspector"
+	polldesc = "a DREAM inspector"
 	spawn_at_outpost = FALSE
 
 /datum/ert/solgov/inspector/New()

--- a/modular_pentest/modules/faction_dream/code/modules/items/devices.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/devices.dm
@@ -29,3 +29,9 @@
 /obj/item/radio/headset/solgov/alt/captain
 	name = "\improper DREAM official bowman headset"
 	desc = "Worn by various officials and leaders from DREAM. Protects ears from flashbangs. Patchouli not included."
+
+	// Encryption key
+
+/obj/item/encryptionkey/solgov
+	name = "\improper DREAM encryption key"
+	icon_state = "solgov_cypherkey" // change?

--- a/modular_pentest/modules/faction_dream/code/modules/items/devices.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/devices.dm
@@ -1,0 +1,31 @@
+// Solgov to DREAM conversion
+
+	// PDA
+
+/obj/item/pda/solgov
+	name = "DREAM PDA"
+	inserted_item = /obj/item/pen/fountain/solgov // shit we need a DREAM pen
+	icon_state = "pda-solgov" // change
+
+	// Radio Headsets
+
+/obj/item/radio/headset/solgov
+	name = "\improper DREAM headset"
+	desc = "Worn by Dreamers."
+	icon_state = "solgov_headset" // change this icon
+	keyslot = new /obj/item/encryptionkey/solgov // do we need to change this?
+
+/obj/item/radio/headset/solgov/captain
+	name = "\improper DREAM official radio headset"
+	desc = "Worn by various officials and leaders from DREAM. Patchouli not included." // i'm never gonna stop with this patchouli thing
+	keyslot2 = new /obj/item/encryptionkey/heads/captain // same question
+	// also should probably add an icon for this one
+
+/obj/item/radio/headset/solgov/alt
+	name = "\improper DREAM bowman headset"
+	desc = "Worn by Dreamers. Protects ears from flashbangs."
+	icon_state = "solgov_headset_alt" // changies
+
+/obj/item/radio/headset/solgov/alt/captain
+	name = "\improper DREAM official bowman headset"
+	desc = "Worn by various officials and leaders from DREAM. Protects ears from flashbangs. Patchouli not included."

--- a/modular_pentest/modules/faction_dream/code/modules/items/drinks.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/drinks.dm
@@ -1,0 +1,21 @@
+// Solgov to DREAM conversion //
+
+/obj/item/reagent_containers/food/drinks/mug/coco
+	name = "Luna's Best Hot Cocoa"
+	desc = "A cup of hot water mixed with chocolate and malted milk powder. A classic hot drink loved by Dreamers the world over."
+
+/obj/item/reagent_containers/food/drinks/soda_cans/cola
+	desc = "Originally made by and for Lunar historical reenactors, this authentic cola has grown remarkably in popularity. Tastes like the sodas of yore."
+
+/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry
+	desc = "A soothing, mellow drink made from ginger. Maybe this will help your tummy feel better. Maybe not." // BRINGING BACK MY ORIGINAL FLAVOR TEXT FROM 2020 WHOOOO
+
+/obj/item/reagent_containers/food/drinks/bottle/vermouth
+	desc = "Dry and sweet vermouth commonly used for mixed drinks. Some Dreamers drink it as a digestive before meals."
+
+/obj/item/reagent_containers/food/drinks/bottle/amaretto
+	desc = "An almond-flavored liqueur that fell into obscurity before it was rediscovered by Lunar historians. The label depicts a nosy-looking AI."
+	icon_state = "disaronno"
+
+/obj/item/reagent_containers/food/drinks/bottle/sake
+	desc = "An alcoholic drink derived from rice, rediscovered and reproduced by Lunar historians."

--- a/modular_pentest/modules/faction_dream/code/modules/items/food.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/food.dm
@@ -1,0 +1,28 @@
+// Solgov to DREAM Conversion //
+
+/obj/item/food/baguette
+	desc = "A traditional Terran bread. Goes well with soft cheese."
+
+/obj/item/food/benedict
+	desc = "A popular breakfast meal consisting of a muffin with ham, a poached egg, and hollandaise. Technically, this is a meal with two eggs involved."
+
+/obj/item/food/cornuto
+	desc = "A vanilla and chocolate ice cream cone with a sprinkling of caramelized nuts."
+
+/obj/item/food/rawkhinkali
+	desc = "One of the many Terran dumplings. This one is in the shape of a twisted knob filled with meat and vegetables. It needs to be boiled."
+
+/obj/item/food/khinkali
+	desc = "One of the many Terran dumplings. This one is in the shape of a twisted knob filled with meat and vegetables."
+
+/obj/item/food/tiris_fondue
+	desc = "Fusion cuisine originating from travelling Lunarians. This fondue is made of Tiris Cheese and filled with small cubes of Dotu-Fime fruit. The flavor profile is reputed to be incredibly rich, especially with crackers."
+
+/obj/item/food/grilled_cheese_sandwich
+	desc = "A sandwich consisting of cheddar or emulsified cheese between two slices of bread. Commonly grilled in a pan."
+
+/obj/item/food/candy_corn
+	desc = "A singular candy corn, originating as a Terran tradition. Interestingly, they are traditionally stored in the interior of a fedora or trilby."
+
+/obj/item/food/chocoorange
+	desc = "A traditional Terran confectionary consisting of orange-infused chocolate made in mimicry of the orange fruit."

--- a/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
@@ -1,0 +1,17 @@
+
+
+// Solgov to DREAM conversion
+
+	// Desk flags
+
+/obj/item/desk_flag/solgov
+	name = "DREAM desk flag"
+	desc = "The flag of the Delegation for the Realization of Equity, Agency, and Meaning."
+	icon_state = "solgov" // change
+
+	// Suit storage unit
+
+/obj/machinery/suit_storage_unit/solgov
+	name = "DREAM suit storage unit"
+
+	// Weapons

--- a/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
@@ -14,4 +14,13 @@
 /obj/machinery/suit_storage_unit/solgov
 	name = "DREAM suit storage unit"
 
-	// Weapons
+	// ID Cards
+
+/obj/item/card/id/solgov
+	name = "\improper DREAM keycard"
+	desc = "A DREAM keycard with no proper access to speak of."
+	icon_state = "solgov" // change
+
+/obj/item/card/id/solgov/commander
+	name = "\improper DREAM commander keycard"
+	desc = "A DREAM keycard with no proper access to speak of. This one indicates a Commander."

--- a/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
@@ -24,3 +24,75 @@
 /obj/item/card/id/solgov/commander
 	name = "\improper DREAM commander keycard"
 	desc = "A DREAM keycard with no proper access to speak of. This one indicates a Commander."
+
+	// Paperwork
+		// we should also add a DREAM pen. SolGov pen overriden elsewhere
+
+/obj/item/folder/solgov
+	desc = "A folder with a DREAM seal."
+	icon_state = "folder_solgov" // change
+
+/obj/item/book/manual/srmlore
+	dat = {"<html>
+			<head>
+			<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body>
+			Notes on the Saint-Roumain Militia:<br>
+			The SRM originated on the planet Illestren, a planet colonized early in the
+			expansionist period of space exploration by colonists. Formed by large
+			group of hunters who banded together to form a sort of citizen's militia.
+			When these colonists came to Illestren, the brought with them the
+			tales of the Ashen Hunter, a figure who came to be venerated by this militia.
+			The Ashen Huntsman is a religious figure venerated by the SRM, said to be able
+			to survive any conditions on their own, and fell any man, creature, or beast
+			with just a single shot from their rifle. The origin of this religious figure
+			is largely unknown and debated by many scholars within the SRM. But they likely
+			originate from a survivalist originating from Sol. The stories of the Ashen
+			Huntsman's valor, glorious hunts, extreme survivalism, and dedication to
+			ascectic practices are passed around by members of the SRM who wish to
+			emulate such glory.<br>
+			Many of the SRM are contracted mercenaries, mostly hired aboard independent
+			vessels. The religious habits amongst members of the organization make them
+			less popular hires for many corporate or government factions. However Nanotrasen
+			doesn't disallow veneration of the Ashen Huntsman on their vessels, making
+			them one of the more common factions for SRM members to serve.<br>
+			The SRM itself is structured around individual companies of hunters. Each SRM
+			vessel is led by a Montagne, who usually owns the ship. Around three to five
+			Hunters, and three Shadows serve alongside them. Hunters are the stock of the
+			SRM, serving as the primary worker and employee. Shadows serve under them,
+			studying and practicing the ways of the ship they serve on, and the SRM
+			at large.<br>
+			The primary source on income for the organization comes from a mix of
+			hunting and weapons manufacturing. Hunts by the SRM range from wiping
+			out large hordes of unruly beasts that pose a threat to their local
+			region, to capturing exotic beasts unharmed for collectors or
+			preservation. Farmers and rich landowners are common patrons of the
+			SRM. Most SRM vessels and outposts will include a workshop known as
+			the "Hunter's Pride". This is where the organization manufactures arms
+			in house. For the most part the SRM produce and rely on manual-action
+			firearms, relying on accuracy and high-caliber munitions over high rate
+			fire or advanced technology. Most old-earth weaponry is produced by
+			the SRM.<br>
+			The practices of members of the SRM are generally ascectic in nature.
+			Automatic and technological firearms are disliked by most hunters
+			within the group, typically favoring blades and single-action firearms.
+			Lightweight clothing and armors are the favored garb of an SRM hunter,
+			with dusters and simple working garbs for safer environments. Resting
+			and eating are also important parts of SRM culture. The soil upon an
+			SRM ship will be imported from the home planet of the Montagne running it,
+			and it serves equally as a place of worship, place of meeting, and a place
+			to sleep. Mealtimes often consist of raw or charred meats from animals raised
+			or hunted by the crew of an SRM vessel. Sometimes these meals are supplemented
+			by simple crops grown in house.<br>
+			Ranking amongst the SRM is by and large non-discriminatory. Rank and status
+			within the organization is decided solely by skill and dedication. While
+			many Montagne lack in skill or time spent within the organization, they
+			will almost always be the most dedicated member aboard.
+			Finally, the SRM comes with a sort of Grand Ideology, one that is usually
+			included aboard SRM vessels in one way or another. The ideology reads thus:
+			“In His name, we maintain dominion over nature,
+			dominion over the chaos of our lives and dominion over ourselves.
+			By defending ourselves and others, we defend His embers.”
+			</body>
+			</html>"}

--- a/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/misc_items.dm
@@ -96,3 +96,29 @@
 			By defending ourselves and others, we defend His embers.”
 			</body>
 			</html>"}
+
+/obj/item/paper/spam/ifmc
+	default_raw_text = {"Greetings sir/madame/other,
+
+I am representative of the Interstellar Frontier Mining Conglomerate, and recent lucerative mining operations in frontier systems have resulted in an approximate profit equal to 40,000,000 credits.
+
+Unfortunately, due to laws regarding monetary transfer, we are unable to transfer monetary profits to our local bank accounts, and we require your assistance in transferring our funding. For facilitating this transfer, the Interstellar Frontier Mining Conglomerate is willing to relinquish 10% or 4,000,000 credits in exchange for services rendered.
+
+To assist us, please wire funding equal to or exceeding 500 credits to the Luna Monetary Fund Account listed below. Upon confirmed reciept of the funding, we will send additional instructions on monetary transfer.
+
+Forward funding to Luna Monetary Fund Account ID: 846584.
+
+Yours truly,
+
+Interstellar Frontier Mining Conglormerate Board of Directors"}
+
+	// Cigars
+
+/obj/item/storage/fancy/cigarettes/cigars/havana
+	desc = "Even after centuries of export, Havana smooth is only found in proper Terran cigars."
+
+	// Consumables
+
+/datum/blackmarket_item/consumable/finobranc
+	desc = "So get this, I know a girl over the internet, and we're chatting, and she sends me these things to try. I figured, hell yeah, try them, and got five days' work done in one day. Now I'm sellin' them. Miracle product, I tell ya."
+

--- a/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
@@ -3,19 +3,57 @@
 	// Melee
 
 /obj/item/melee/sword/sabre/solgov
-	name = "lunar sabre"
+	name = "Lunar sabre"
 	desc = "A refined ceremonial blade often given to peace officers and high ranking officials of DREAM."
 	icon_state = "sabresolgov" // change
 	item_state = "sabresolgov" // change
 
 /obj/item/storage/belt/sabre/solgov
-	name = "lunar sabre sheath"
+	name = "Lunar sabre sheath"
 	desc = "An ornate sheath designed to hold an officer's blade."
 	base_icon_state = "sheath-solgov" // change
 	icon_state = "sheath-solgov" // change
 	item_state = "sheath-solgov" // change
 
+/obj/item/melee/sword/sabre/suns
+	desc = "A blade of Lunar origin given to SUNS followers."
+
 	// Ammo
 
 /datum/supply_pack/ammo/c556mmHITP_ammo_box
 	desc = "Contains a 48-round 5.56mm caseless box for sidearms like the Pistole C."
+
+/datum/blackmarket_item/ammo/gauss_cell
+	name = "DREAM Weapon Cell"
+	desc = "A Lunar weapon cell for powering gauss weaponry."
+
+	// Design disks
+
+/datum/blackmarket_item/weapon/disposable_gun_disk
+	desc = "An autolathe-compatible fabrication disk for printing disposable guns chambered in .22 LR. Improper disposal or recycling of these guns is an environmental misdemeanor in the Sol system. Luckily, we aren't in the Sol system, so litter all you want."
+
+	// Supply packs
+
+/datum/supply_pack/ammo/a858
+	desc = "Contains a twenty-round 8x58 ammo box for Lunar sniper rifles, such as the SSG-69."
+
+/datum/supply_pack/gun/pistolec
+	desc = "Contains a compact Lunar sidearm chambered in 5.56mm HITP. Not to be confused with 5.56x42 CLIP."
+
+/datum/supply_pack/gun/modelh
+	desc = "Contains a compact Lunar gauss pistol chambered in ferromagnetic slugs. Remember to sign your necessary forms upon arrival."
+
+/datum/supply_pack/gun/gar
+	name = "Lunar 'GAR' Automatic Rifle"
+	desc = "A modern Lunar military rifle chambered in ferromagnetic lances. Not for export."
+
+/datum/supply_pack/gun/ssg669
+	desc = "Contains a traditional Lunar marksman rifle chambered in 8x58mm Caseless."
+
+/datum/supply_pack/magazine/solgovcell
+	name = "DREAM Weapon Cell Crate"
+	desc = "Contains a weapon cell compatible with Lunar gauss weaponry."
+
+/datum/supply_pack/spacesuits/spacesuit/solgov
+	name = "Lunar Vacsuit Crate"
+	desc = "Contains one Tortoise Microlite Armored Suit, the pride and joy of many Lunar explorers."

--- a/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
@@ -1,0 +1,9 @@
+// Solgov to DREAM conversion
+
+	// Melee
+
+/obj/item/melee/sword/sabre/solgov
+	name = "lunar sabre"
+	desc = "A refined ceremonial blade often given to peace officers and high ranking officials of DREAM."
+	icon_state = "sabresolgov" // change
+	item_state = "sabresolgov" // change

--- a/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/items/weapons.dm
@@ -7,3 +7,15 @@
 	desc = "A refined ceremonial blade often given to peace officers and high ranking officials of DREAM."
 	icon_state = "sabresolgov" // change
 	item_state = "sabresolgov" // change
+
+/obj/item/storage/belt/sabre/solgov
+	name = "lunar sabre sheath"
+	desc = "An ornate sheath designed to hold an officer's blade."
+	base_icon_state = "sheath-solgov" // change
+	icon_state = "sheath-solgov" // change
+	item_state = "sheath-solgov" // change
+
+	// Ammo
+
+/datum/supply_pack/ammo/c556mmHITP_ammo_box
+	desc = "Contains a 48-round 5.56mm caseless box for sidearms like the Pistole C."

--- a/modular_pentest/modules/faction_dream/code/modules/machinery/machinery.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/machinery/machinery.dm
@@ -34,3 +34,25 @@
 /obj/machinery/telecomms/server/presets/solgov
 	id = "DREAM Server"
 	autolinkers = list("DREAM", "broadcasterA")
+
+	// Coffee Maker
+
+/obj/machinery/coffeemaker
+	name = "coffee maker"
+	desc = "An Attention-model coffee maker imported from Luna, where it is extremely popular."
+
+	// Turrets
+
+
+/obj/machinery/porta_turret/ship/solgov
+	name = "Type Fauchard Emplacement" // change
+	desc = "A long range turret manufactured by Quin Technologies. It is rated for combat usage, and has a higher than average lethality index."
+
+
+/obj/machinery/porta_turret/ship/solcon/slug
+	name = "Type Guisarme Emplacement" // change
+	desc = "A short range turret emplacement manufactured by Quin Technologies. The slug rounds used have given it a reputation for incredible effect against unarmored targets, and performance issues at range."
+
+/obj/machinery/porta_turret/ship/solcon/lance
+	name = "Type Glaive Emplacement" // change
+	desc = "A heavy turret emplacement manufactured by Quin Technologies. Long cycle time between volleys is the only weakness attributed to the turret, as it is effective against targets up to exo-armor."

--- a/modular_pentest/modules/faction_dream/code/modules/machinery/machinery.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/machinery/machinery.dm
@@ -1,0 +1,36 @@
+// Solgov to DREAM conversion
+
+	// Fax
+
+/obj/machinery/fax/admin/solgov
+	name = "DREAM Frontier Affairs Fax Machine"
+	fax_name = "DREAM Frontier Affairs"
+
+/obj/machinery/fax/solgov
+	special_networks = list(
+		list(fax_name = "Outpost Authority", fax_id = "outpost", color = "orange", emag_needed = FALSE),
+		list(fax_name = "DREAM Frontier Affairs", fax_id = "solgov", color = "teal", emag_needed = FALSE),
+		list(fax_name = "Frontiersmen Communications Quartermaster", fax_id = "frontiersmen", color = "black", emag_needed = TRUE)
+	)
+
+	// Suit storage
+
+/obj/machinery/suit_storage_unit/solgov
+	name = "DREAM suit storage unit"
+
+	// Telecomms
+
+/obj/machinery/telecomms/bus/preset_seven
+	id = "DREAM Communications Bus"
+	autolinkers = list("processor7", "DREAM", "receiverA", "messaging")
+
+/obj/machinery/telecomms/processor/preset_seven
+	id = "DREAM Communications Processor"
+
+/obj/machinery/telecomms/relay/preset/solgov
+	id = "DREAM Relay"
+	network = "DREAM_commnet"
+
+/obj/machinery/telecomms/server/presets/solgov
+	id = "DREAM Server"
+	autolinkers = list("DREAM", "broadcasterA")

--- a/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
@@ -1,0 +1,35 @@
+// Solgov to DREAM conversion
+
+	// Posters
+
+		// I mostly just changed the ones that directly reference SolGov.
+
+/obj/structure/sign/poster/solgov
+	poster_item_name = "DREAM poster"
+	poster_item_desc = "A poster produced by DREAM, made with natural paper! It comes with adhesive backing, for easy pinning to any vertical surface."
+	poster_item_icon_state = "rolled_legit"
+
+/obj/structure/sign/poster/solgov/random
+	name = "random DREAM poster"
+	icon_state = "random_solgov" // change, i guess
+
+/obj/structure/sign/poster/solgov/solgov_logo
+	name = "DREAM"
+	desc = "The DREAM insignia. Inspiring."
+	icon_state = "poster-solgov" // change
+
+/obj/structure/sign/poster/solgov/terra // keep icon as is, all I did was tweak the description a bit
+	desc = "Terra, or Earth as it's called by inhabitants, the third planet in the Sol system. Home to the only life as humans knew it, until contact with the outside universe."
+
+/obj/structure/sign/poster/solgov/luna
+	desc = "Luna, the only moon of Terra and the spiritual home of Dreamers."
+
+/obj/structure/sign/poster/solgov/sonnensoldner
+	name = "The Peace Officers"
+	desc = "The beloved heroes of DREAM."
+	icon_state = "poster-solgov-sonnensoldner" // change
+
+/obj/structure/sign/poster/solgov/solgov_enlist
+	name = "Discover Your Future"
+	desc = "Join DREAM and make a difference!"
+	icon_state = "poster_solgov_enlist_legit" // change

--- a/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
@@ -1,38 +1,6 @@
 // Solgov to DREAM conversion
 
-	// Posters
-
-		// I mostly just changed the ones that directly reference SolGov.
-
-/obj/structure/sign/poster/solgov
-	poster_item_name = "DREAM poster"
-	poster_item_desc = "A poster produced by DREAM, made with natural paper! It comes with adhesive backing, for easy pinning to any vertical surface."
-	poster_item_icon_state = "rolled_legit"
-
-/obj/structure/sign/poster/solgov/random
-	name = "random DREAM poster"
-	icon_state = "random_solgov" // change, i guess
-
-/obj/structure/sign/poster/solgov/solgov_logo
-	name = "DREAM"
-	desc = "The DREAM insignia. Inspiring."
-	icon_state = "poster-solgov" // change
-
-/obj/structure/sign/poster/solgov/terra // keep icon as is, all I did was tweak the description a bit
-	desc = "Terra, or Earth as it's called by inhabitants, the third planet in the Sol system. Home to the only life as humans knew it, until contact with the outside universe."
-
-/obj/structure/sign/poster/solgov/luna
-	desc = "Luna, the only moon of Terra and the spiritual home of Dreamers."
-
-/obj/structure/sign/poster/solgov/sonnensoldner
-	name = "The Peace Officers"
-	desc = "The beloved heroes of DREAM."
-	icon_state = "poster-solgov-sonnensoldner" // change
-
-/obj/structure/sign/poster/solgov/solgov_enlist
-	name = "Discover Your Future"
-	desc = "Join DREAM and make a difference!"
-	icon_state = "poster_solgov_enlist_legit" // change
+	// Poster overrides located in modular_pentest\modules\posters\code\poster_overrides.dm
 
 	// Signs
 

--- a/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
+++ b/modular_pentest/modules/faction_dream/code/modules/objects/structures.dm
@@ -33,3 +33,26 @@
 	name = "Discover Your Future"
 	desc = "Join DREAM and make a difference!"
 	icon_state = "poster_solgov_enlist_legit" // change
+
+	// Signs
+
+/obj/structure/sign/solgov_seal
+	name = "DREAM insignia"
+	desc = "An insignia depicting four hearts in harmony."
+	icon = 'icons/obj/solgov_logos.dmi'
+	icon_state = "solgovseal" // change
+
+/obj/structure/sign/solgov_flag
+	name = "DREAM banner"
+	desc = "A banner displaying the insignia for DREAM, the Delegation for the Realization of Equity, Agency, and Meaning."
+	icon = 'icons/obj/solgov_logos.dmi'
+	icon_state = "solgovflag-left" // change
+
+	// Airlock assembly
+
+/obj/structure/door_assembly/door_assembly_sgv
+	name = "DREAM airlock assembly"
+	icon = 'icons/obj/doors/airlocks/station/solgov.dmi' // change
+	base_name = "DREAM airlock"
+	glass_type = /obj/machinery/door/airlock/solgov/glass
+	airlock_type = /obj/machinery/door/airlock/solgov

--- a/modular_pentest/modules/faction_dream/readme.md
+++ b/modular_pentest/modules/faction_dream/readme.md
@@ -1,0 +1,33 @@
+https://github.com/PentestSS13/Pentest/pull/571
+
+## \ <DREAM>
+
+Module ID:DREAM
+
+### Description:
+
+Add DREAM faction items and converts SolGov items to DREAM.
+
+### Shiptest Proc/File Changes:
+
+- N/A
+
+### Modular Overrides:
+
+- Overrides numerous references to SolGov and redescribes or reroutes to DREAM: antagonists, areas, clothing, datums (ERT), items, jobs, machinery, objects (e.g., signs).
+
+### Defines:
+
+- N/A
+
+### Map additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+
+OnlineGirlfriend

--- a/modular_pentest/modules/solgov_removal/code/misc_overrides.dm
+++ b/modular_pentest/modules/solgov_removal/code/misc_overrides.dm
@@ -1,0 +1,36 @@
+// Removes SolGov and Night of Fire references that aren't removed elsewhere; if you find a better place for one of these overrides, feel free to move it
+
+
+// Supply packs
+
+/datum/blackmarket_item/clothing/frontiersmen_armor_fireproof
+	desc = "Get it while it's hot! This fire-proofed armor and uniform set is made with a miracle material that renders it almost impervious to flames. The Frontiersmen swear by the stuff. It's kept each of its previous owners safe until they passed away from illness."
+
+/datum/supply_pack/emergency/radiation
+	desc = "Survive nuclear wars and overclocked engines alike with this radiation suit. Contains a helmet, suit, and Geiger counter. Comes with a glass of vodka and commemorative shot glass."
+
+// Food and drink
+
+/obj/item/reagent_containers/food/drinks/bottle/champagne
+	desc = "Finely sourced from entire canton planets dedicated to faithful reproduction of old Terran vineyards. Typically enjoyed for celebrations and the turn of new years."
+
+// Gun
+
+/obj/item/gun/ballistic/automatic/smg/vector
+	desc = "A police carbine based on an old Terran SMG design. Most of the complex workings have been removed for reliability. Chambered in 9x18mm."
+
+// Language
+
+/datum/language/solarian_international
+	name = "Solarian International Standard"
+	desc = "An unnatural fusion of Solarian languages that, once separate, somehow coalesced into a single language completely devoid of personality."
+	syllables = list(
+		"und", "ver", "sic", "men", "die", "ich", "end", "ach", "ber",
+		"ste", "ung", "der", "das", "de",  "kau", "lin", "aud","en","er", //german-swiss syllables: reduced the sheer number of these compared to Shiptest
+		"een", "aar", "het", "ver", "oor", "ee", "an", "et", "aa", "oo", "ve", "ing", //dutch/afrikaans syllables
+		"ali", "kuw", "uwa", "kwa", "ati", "iku", "wa", "ku", "na", "ka", "li", "ma", //swahili syllables
+		"ent", "que", "nte", "par", "ara", "ra", "ar", "es", //portuguese(brazilian) syllables
+		"ang", "kan", "dan", "nga", "ng", "ya", //indonesian syllables
+		"xia", "li", "ni", "da", "guo", "fu", "xin", "zai", "wo", "cai", "yao", "yuan", "bo", "ai", // HI PENTEST CODER HERE: TAIWAN #1
+	)
+	icon_state = "solarian"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Converting SolGov to DREAM, a Lunar NGO that provides humanitarian aid.

**Done thus far:**
Names and descriptions for:
* Clothing
* Job titles
* Posters and signs
* Machinery
* Weapons/ammo

**Icons:**
- Solgov bedsheets now use DREAM icon
- Solgov posters repath to DREAM posters

**_No other icons have been changed yet. The biggest thing we need to do is replace all the armor and signs_**

**Also includes:**
- Miscellaneous overrides removing references to Solgov and Night of Fire that were otherwise unrelated to the DREAM conversion
- Override modifying Solarian International Standard to be less German-heavy and incorporate Chinese (which technically is in line with DREAM), though if you'll allow me to rename this language entirely I think that would be sick af
- Replaces some instances of "Solarian" with "Terran" or "Lunar"

**Note on Modularization**

- This PR currently contains one change to Shiptest's fax.dm. I might change this especially if vect0r notices

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We do not want SolGov.  DREAM is the proposed replacement.  I think it will overall be a pleasant change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
