### PR TITLE
[In progress] Fixes spelling/grammar errors in other_reagents.dm

### DIFF
--- a/modular_pentest/modules/spelling_overrides/code/other_reagents.dm
+++ b/modular_pentest/modules/spelling_overrides/code/other_reagents.dm
@@ -1,0 +1,259 @@
+// Contains overrides for other_reagents.dm //
+	// PROC OVERRIDES CONTAINED IN THIS FILE: Genesis
+
+/datum/reagent/liquidgibs
+	name = "Liquid Gibs"
+
+/datum/reagent/water/hollowwater
+	taste_description = "emptiness"
+
+/datum/reagent/hydrogen_peroxide
+	name = "Hydrogen Peroxide"
+
+/datum/reagent/ozone
+	description = "A pale blue gas with a distinct smell. While it is oxygen with an extra molecule attached, it is quite dangerous."
+
+/datum/reagent/sulfur
+	description = "A sickly yellow solid mostly known for its nasty smell. It's actually much more helpful than it looks in biochemistry."
+
+/datum/reagent/chlorine
+	description = "A pale yellow gas that's well known as an oxidizer. While it forms many harmless molecules in its elemental form, it is far from harmless."
+
+/datum/reagent/fluorine
+	description = "A comically reactive chemical element. The universe does not want this stuff to exist in this form in the slightest."
+
+/datum/reagent/lithium
+	description = "A silver metal. Its claim to fame is its remarkably low density. Using it is a bit too effective in calming oneself down."
+
+/datum/reagent/uranium
+	description = "A jade-green actinide. Weakly radioactive."
+
+/datum/reagent/bluespace
+	description = "A dust composed of microscopic bluespace crystals with minor space-warping properties."
+
+/datum/reagent/fuel
+	name = "Welding Fuel"
+
+/datum/reagent/space_cleaner
+	name = "Space Cleaner"
+
+/datum/reagent/foaming_agent
+	name = "Foaming Agent"
+
+/datum/reagent/smart_foaming_agent
+	name = "Smart Foaming Agent"
+
+/datum/reagent/diethylamine
+	description = "A secondary amine. Mildly corrosive."
+
+/datum/reagent/freon
+	description = "A powerful refrigerant."
+
+/datum/reagent/plantnutriment
+	name = "Generic Nutriment"
+
+/datum/reagent/plantnutriment/endurogrow
+	description = "A specialized nutriment that decreases product quantity and potency but strengthens the plant's endurance."
+
+/datum/reagent/plantnutriment/liquidearthquake
+	description = "A specialized nutriment that increases the plant's production speed as well as its susceptibility to weeds."
+
+/datum/reagent/fuel/oil
+	description = "Burns in a small smoky fire. Can be used to produce ash."
+
+/datum/reagent/stable_plasma
+	description = "Non-flammable plasma locked in a liquid form that cannot ignite or change states."
+
+/datum/reagent/iodine
+	description = "Commonly added to table salt as a nutrient. On its own, it tastes far less pleasing."
+
+/datum/reagent/carpet/black
+	description = "The carpet also comes in... BLAPCK."
+
+/datum/reagent/carpet/royal/black
+	description = "For those that feel the need to show off their time-wasting skills."
+
+/datum/reagent/carpet/royal/blue
+	description = "For those that feel the need to show off their time-wasting skills... in BLUE."
+
+// Genesis proc override -- only changes the visible messages //
+
+/datum/reagent/genesis/expose_turf(turf/exposed_turf, reac_volume)
+	var/allowed = FALSE
+	for(var/turf/checked_turf as anything in turf_whitelist)
+		if(!istype(exposed_turf, checked_turf))
+			continue
+		else
+			allowed = TRUE
+			break
+	if(!allowed)
+		return ..()
+
+	if(isopenturf(exposed_turf))
+		var/turf/open/floor/terraform_target = exposed_turf
+
+		if(istype(terraform_target, /turf/open/lava) || istype(terraform_target, /turf/open/water/acid))
+			if(istype(terraform_target, /turf/open/lava))
+				terraform_target.ChangeTurf(/turf/open/floor/plating/asteroid/basalt/lava_land_surface/basin, flags = CHANGETURF_INHERIT_AIR)
+			if(istype(terraform_target, /turf/open/water/acid))
+				terraform_target.ChangeTurf(/turf/open/floor/plating/asteroid/whitesands/dried, flags = CHANGETURF_INHERIT_AIR)
+			terraform_target.visible_message("<span class='notice'>As the serum touches [terraform_target.name], it all starts drying up, leaving a dry basin behind!</span>")
+			playsound(exposed_turf, 'sound/effects/bubbles.ogg', 50)
+			return ..()
+
+		if(istype(terraform_target, /turf/open/floor/plating/asteroid/basalt/lava_land_surface/basin) || istype(terraform_target, /turf/open/floor/plating/asteroid/whitesands/dried)|| istype(terraform_target, /turf/open/floor/plating/asteroid/sand)) //if basin, replace with water
+			return ..()
+
+		if(istype(terraform_target, /turf/open/floor/plating/asteroid/purple))
+			terraform_target.ChangeTurf(/turf/open/floor/plating/asteroid/sand/terraform, flags = CHANGETURF_INHERIT_AIR)
+			terraform_target.visible_message("<span class='notice'>The chemicals in the sand dissolve, and the sand looks more natural.</span>")
+			playsound(exposed_turf, 'sound/effects/bubbles.ogg', 50)
+			return ..()
+
+		if(!istype(terraform_target, /turf/open/floor/plating/asteroid/dirt)) // if not dirt, acutally terraform
+			terraform_target.ChangeTurf(/turf/open/floor/plating/asteroid/dirt, flags = CHANGETURF_INHERIT_AIR)
+			terraform_target.visible_message("<span class='notice'>The harsh land becomes fertile dirt, but more work needs to be done for it to be growable and breathable. Perhaps add grass?</span>")
+			playsound(exposed_turf, 'sound/effects/bubbles.ogg', 50)
+			return ..()
+
+
+		if(istype(terraform_target, /turf/open/floor/plating/asteroid/dirt/grass)) //if grass, plant shit
+			for(var/obj/object as anything in terraform_target.contents)
+				if(!istype(object, /obj/structure/flora))
+					continue
+				terraform_target.visible_message("<span class='danger'>There's already flora on the tile!</span>")
+				return ..()
+
+			terraform_target.visible_message("<span class='notice'>As the serum touches the grass, flora suddenly grows out of it!</span>")
+			playsound(exposed_turf, 'sound/effects/bubbles.ogg', 50)
+			if(prob(70))
+				new /obj/effect/spawner/random/flower(exposed_turf)
+			else if(prob(5))
+				new /obj/structure/flora/ash/garden(exposed_turf)
+			else
+				new /obj/effect/spawner/random/flora(exposed_turf)
+
+	return ..()
+
+/datum/reagent/lye
+	description = "Also known as sodium hydroxide. As a profession, making this is somewhat underwhelming."
+
+/datum/reagent/drying_agent
+	name = "Drying Agent"
+
+/datum/reagent/toxin/mutagen/mutagenvirusfood
+	name = "Mutagenic Agar"
+
+/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar
+	name = "Sucrose Agar"
+
+/datum/reagent/medicine/synaptizine/synaptizinevirusfood
+	name = "Virus Rations"
+
+/datum/reagent/toxin/plasma/plasmavirusfood
+	name = "Virus Plasma"
+
+/datum/reagent/toxin/plasma/plasmavirusfood/weak
+	name = "Weakened Virus Plasma"
+
+/datum/reagent/uranium/uraniumvirusfood
+	name = "Decaying Uranium Gel"
+
+/datum/reagent/uranium/uraniumvirusfood/unstable
+	name = "Unstable Uranium Gel"
+
+/datum/reagent/uranium/uraniumvirusfood/stable
+	name = "Stable Uranium Gel"
+
+/datum/reagent/royal_bee_jelly
+name = "Royal Bee Jelly"
+	description = "Royal Bee Jelly. Injecting this into a Queen Space Bee will cause her to split into two bees."
+
+/datum/reagent/romerol
+	description = "Romerol is a highly experimental bioterror agent \
+		that causes dormant nodules to be etched into the grey matter of \
+		the subject. These nodules only become active upon the death of the \
+		host, at which time the secondary structures activate and take \
+		control of the host body."
+
+/datum/reagent/magillitis
+		description = "An experimental serum that causes rapid muscular growth in Hominidae. Side effects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
+
+/datum/reagent/growthserum
+	description = "A strange chemical that causes growth but wears off over time. The growth effect is limited."
+
+/datum/reagent/plastic_polymers
+	name = "Plastic Polymers"
+	description = "Petroleum-based components of plastic."
+
+/datum/reagent/glitter
+	name = "Generic Glitter"
+	description = "If you can see this description, contact a coder."
+
+/datum/reagent/glitter/pink
+	name = "Pink Glitter"
+	description = "Pink sparkles that get everywhere."
+
+/datum/reagent/glitter/white
+	name = "White Glitter"
+	description = "White sparkles that get everywhere."
+
+/datum/reagent/glitter/blue
+	name = "Blue Glitter"
+	description = "Blue sparkles that get everywhere."
+
+/datum/reagent/bz_metabolites
+	name = "BZ Metabolites"
+
+/datum/reagent/peaceborg/confuse
+	name = "Dizzying Solution"
+	description = "Makes the target off balance and dizzy."
+
+/datum/reagent/peaceborg/tire
+	name = "Tiring Solution"
+	description = "An extremely weak stamina toxin that tires out the target. Completely harmless."
+
+/datum/reagent/spider_extract
+	name = "Spider Extract"
+	description = "A highly specialized extract coming from the Australicus sector. Used to create broodmother spiders."
+
+/datum/reagent/yuck
+	glass_desc = "It smells like a carcass and doesn't look much better."
+
+/datum/reagent/metalgen
+	description = "A purple metal morphic liquid said to impose its metallic properties on whatever it touches."
+
+/datum/reagent/gravitum
+	description = "A rare kind of null fluid capable of temporarily removing all weight of whatever it touches."
+
+/datum/reagent/cellulose
+	description = "A crystaline polydextrose polymer. Plants swear by this stuff."
+
+/datum/reagent/liquidadamantine
+	description = "A legendary life-giving metal, liquified."
+	taste_description = "life-giving metal"
+
+/datum/reagent/three_eye
+	description = "Out on the edge of human space, at the limits of scientific understanding and \
+	cultural taboo, people develop and dose themselves with substances that would curl the hair on \
+	a brinker's vat-grown second head. Three Eye is one of the most notorious narcotics to ever come \
+	out of the independent habitats, and it has about as much in common with recreational drugs as a \
+	Stok does with an Unathi strike trooper. It is equally effective on humans, Skrell, dionaea, and \
+	probably the Captain's cat. Distributing it will get you guaranteed jail time in every \
+	human territory."
+
+/datum/reagent/cement/roadmix
+	name = "Road Mixture"
+
+/datum/reagent/concrete
+		description = "A mix of cement and aggregate. Commonly used as a bulk building material."
+
+/datum/reagent/calcium
+	description = "A dull grey metal important to bones."
+
+/datum/reagent/polar_bear_fur
+	description = "Fur obtained from griding up a polar bear's hide."
+
+/datum/reagent/anti_radiation_foam
+	description = "A tried-and-tested foam used for decontaminating nuclear disasters."
+	taste_description = "bitter, foamy awfulness"

--- a/modular_pentest/modules/spelling_overrides/code/other_reagents.dm
+++ b/modular_pentest/modules/spelling_overrides/code/other_reagents.dm
@@ -166,7 +166,7 @@
 	name = "Stable Uranium Gel"
 
 /datum/reagent/royal_bee_jelly
-name = "Royal Bee Jelly"
+	name = "Royal Bee Jelly"
 	description = "Royal Bee Jelly. Injecting this into a Queen Space Bee will cause her to split into two bees."
 
 /datum/reagent/romerol
@@ -177,7 +177,7 @@ name = "Royal Bee Jelly"
 		control of the host body."
 
 /datum/reagent/magillitis
-		description = "An experimental serum that causes rapid muscular growth in Hominidae. Side effects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
+	description = "An experimental serum that causes rapid muscular growth in Hominidae. Side effects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
 
 /datum/reagent/growthserum
 	description = "A strange chemical that causes growth but wears off over time. The growth effect is limited."
@@ -246,7 +246,7 @@ name = "Royal Bee Jelly"
 	name = "Road Mixture"
 
 /datum/reagent/concrete
-		description = "A mix of cement and aggregate. Commonly used as a bulk building material."
+	description = "A mix of cement and aggregate. Commonly used as a bulk building material."
 
 /datum/reagent/calcium
 	description = "A dull grey metal important to bones."

--- a/modular_pentest/modules/spelling_overrides/readme.md
+++ b/modular_pentest/modules/spelling_overrides/readme.md
@@ -1,4 +1,4 @@
-https://github.com/PentestSS13/Pentest/pull/<!--PR Number-->
+https://github.com/PentestSS13/Pentest/pull/646
 
 ## Spelling Overrides
 

--- a/modular_pentest/modules/spelling_overrides/readme.md
+++ b/modular_pentest/modules/spelling_overrides/readme.md
@@ -1,0 +1,31 @@
+https://github.com/PentestSS13/Pentest/pull/<!--PR Number-->
+
+## Spelling Overrides
+
+Module ID: SPELLING_OVERRIDES
+
+### Description:
+
+Contains overrides for miscellaneous item names/descriptions/etc that will fix spelling and grammar errors as well as ensure consistency with our lore. If for whatever reason such an error can't or won't be fixed upstream, I will contain here if no other relevant override files exists. If those errors are later fixed upstream, you should remove them from this file.
+
+### Shiptest Proc/File Changes:
+
+- Overrides Genesis terraforming proc in other_reagents.dm (only changes visible messages to eliminate spelling errors)
+
+### Modular Overrides:
+
+- Overrides various names/descriptions in other_reagents.dm
+
+### Defines:
+
+- N/A
+
+### Map additions
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits: OnlineGirlfriend
+

--- a/modular_pentest/~pentest.dme
+++ b/modular_pentest/~pentest.dme
@@ -374,6 +374,7 @@
 #include "modules\shotshells\code\converter.dm"
 #include "modules\shotshells\code\shotshells.dm"
 #include "modules\soggy_woggies\code\soggy_woggies.dm"
+#include "modules\spelling_overrides\code\other_reagents.dm"
 #include "modules\spessknife\code\spess_knife.dm"
 #include "modules\surgery\code\wing_reconstruction.dm"
 #include "modules\swarmers\code\megafauna_swarmer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Creates spelling_overrides folder for misc. spelling/grammar errors that for whatever reason must be fixed via an override and do not otherwise have a pertinent override file

Fixes a number of spelling/grammar errors in the following files:
* other_reagents.dm (includes override for the Genesis terraforming proc, which solely corrects visible messages) (I have a PR pending upstream with the same fixes, so if that is merged and applied here, I will retract these changes)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Fixes a large number of errors in reagent descriptions and establishes a consistent capitalization scheme for reagent names
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
spellcheck: other_reagents.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
